### PR TITLE
Remove pr0gramm.com

### DIFF
--- a/Pihole-Prigent-Crypto.txt
+++ b/Pihole-Prigent-Crypto.txt
@@ -10996,7 +10996,6 @@ pqpcgykgtyrfdh.bid
 pqrzmcyfgbnn.bid
 pqwbcpqqiiznu.bid
 pr0gram.org
-pr0gramm.com
 praeicwgzapf.com
 prbitcoin.com
 premiumminer.com


### PR DESCRIPTION
[pr0gramm.com](https://pr0gramm.com/imprint) is a german imageboard hosted by the Interdimensionale GmbH registered at the district court in Darmstadt, Germany. It has nothing to do with crypto mining.